### PR TITLE
remove redundant Cargo.toml section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,3 @@ name = "pitch_calc"
 version = "0.1.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 
-[lib]
-name = "pitch_calc"
-


### PR DESCRIPTION
This is the default, so no need
