### PR TITLE
Implement From<T> for all pitch types.

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,68 @@
+use std::convert::From;
+use calc::Hz as CalcHz;
+use super::{LetterOctave, Step, Mel, Perc, ScaledPerc, Hz};
+
+/// Implement a single From<T> using the passed expression
+macro_rules! impl_from {
+    ($FromType:ty, $ToType:ty, $id:ident => $conv:expr) => {
+        impl From<$FromType> for $ToType {
+            fn from($id: $FromType) -> Self {
+                $conv
+            }
+        }
+    };
+
+    ($FromType:ty, $ToType:ty, $member:ident) => {
+        impl_from!($FromType, $ToType, other => other.$member());
+    };
+}
+
+/// Implement all type pairs using their respective conversion functions
+macro_rules! impl_all_pairs {
+    ( $member:ident => $To:ty ) => { };
+
+    ( $head_member:ident => $Head:ty, $( $tail_member:ident => $Tail:ty ),* )
+        => {
+        $(
+            impl_from!($Head, $Tail, $tail_member);
+            impl_from!($Tail, $Head, $head_member);
+        )*
+
+        impl_all_pairs!($($tail_member => $Tail),*);
+    }
+}
+
+/// Implement From<T> for all fully defined pitch types
+impl_all_pairs!(
+    to_hz => Hz,
+    to_mel => Mel,
+    to_letter_octave => LetterOctave,
+    to_scaled_perc => ScaledPerc,
+    to_perc => Perc,
+    to_step => Step
+    );
+
+/// Additionally implement From for calc::Hz = f32
+impl_from!(CalcHz, Hz, other => Hz(other));
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Into;
+    use super::super::*;
+
+    fn into_test_gen<T: Into<Hz>>(val: T) -> Hz {
+        val.into()
+    }
+
+    #[test]
+    fn conversion() {
+        let lo = LetterOctave(Letter::A, 4);
+        assert!(Hz::from(lo) == Hz(440.0));
+    }
+
+    #[test]
+    fn function_call() {
+        let lo = LetterOctave(Letter::A, 4);
+        assert!(into_test_gen(lo) == Hz(440.0));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,4 +71,5 @@ pub mod perc;
 pub mod scaled_perc;
 pub mod step;
 pub mod utils;
+pub mod convert;
 


### PR DESCRIPTION
To simplify things like synth's `note_on` and `note_off` functions this adds a `ToHz` trait that provides the two methods `hz` which produces a `f32` and `to_hz` which gives a `Hz` object. The trait is implemented for all absolute types and the corresponding functions have been removed from the respective struct `impl`s.