### PR TITLE
Apply clippy lints

### DIFF
--- a/src/calc.rs
+++ b/src/calc.rs
@@ -95,7 +95,7 @@ pub fn letter_octave_from_scaled_perc(scaled: Perc, weight: Weight) -> (Letter, 
 #[inline]
 pub fn letter_octave_from_step(step: Step) -> (Letter, Octave) {
     let rounded = step.round() as Octave;
-    let letter_step = modulo(rounded, TOTAL_LETTERS as Octave);
+    let letter_step = modulo(rounded, Octave::from(TOTAL_LETTERS));
     (FromPrimitive::from_i32(letter_step).unwrap(), (rounded - letter_step) / 12 - MIDI_OCTAVE_OFFSET)
 }
 
@@ -133,7 +133,7 @@ pub fn mel_from_step(step: Step) -> Mel {
 /// Calculate percentage from hz.
 #[inline]
 pub fn perc_from_hz(hz: Hz) -> Perc {
-    (hz - MIN_HZ) as Perc / (MAX_HZ - MIN_HZ) as Perc
+    Perc::from(hz - MIN_HZ) / Perc::from(MAX_HZ - MIN_HZ)
 }
 
 /// Calculate percentage from letter octave.
@@ -151,7 +151,7 @@ pub fn perc_from_mel(mel: Mel) -> Perc {
 /// Calculate percentage from scaled percentage.
 #[inline]
 pub fn perc_from_scaled_perc(scaled: Perc, weight: Weight) -> Perc {
-    scaled.powf(weight as Perc)
+    scaled.powf(Perc::from(weight))
 }
 
 /// Calculate frequency percentage from pitch as `step`.
@@ -181,7 +181,7 @@ pub fn scaled_perc_from_mel(mel: Mel, weight: Weight) -> Perc {
 /// Calculate scaled percentage from percentage.
 #[inline]
 pub fn scaled_perc_from_perc(perc: Perc, weight: Weight) -> Perc {
-    perc.powf(1.0 / weight as Perc)
+    perc.powf(1.0 / Perc::from(weight))
 }
 
 /// Calculate scaled frequency percentage from pitch as `step`.

--- a/src/hz.rs
+++ b/src/hz.rs
@@ -27,105 +27,103 @@ pub const MIN: calc::Hz = 20.0;
 pub struct Hz(pub calc::Hz);
 
 impl Hz {
-
     /// Return the unit value of the Hz struct.
     #[inline]
-    pub fn hz(&self) -> calc::Hz {
-        let Hz(hz) = *self;
+    pub fn hz(self) -> calc::Hz {
+        let Hz(hz) = self;
         hz
     }
 
     /// Convert to (Letter, Octave) tuple.
     #[inline]
-    pub fn letter_octave(&self) -> (Letter, Octave) {
-        let Hz(hz) = *self;
+    pub fn letter_octave(self) -> (Letter, Octave) {
+        let Hz(hz) = self;
         letter_octave_from_hz(hz)
     }
 
     /// Convert to Letter.
     #[inline]
-    pub fn letter(&self) -> Letter {
+    pub fn letter(self) -> Letter {
         let (letter, _) = self.letter_octave();
         letter
     }
 
     /// Convert to Octave.
     #[inline]
-    pub fn octave(&self) -> Octave {
+    pub fn octave(self) -> Octave {
         let (_, octave) = self.letter_octave();
         octave
     }
 
     /// Convert to a LetterOctave struct with the same pitch.
     #[inline]
-    pub fn to_letter_octave(&self) -> LetterOctave {
+    pub fn to_letter_octave(self) -> LetterOctave {
         let (letter, octave) = self.letter_octave();
         LetterOctave(letter, octave)
     }
 
     /// Convert to the unit value of a Mel.
     #[inline]
-    pub fn mel(&self) -> calc::Mel {
+    pub fn mel(self) -> calc::Mel {
         mel_from_hz(self.hz())
     }
 
     /// Convert to a Mel struct.
     #[inline]
-    pub fn to_mel(&self) -> Mel {
+    pub fn to_mel(self) -> Mel {
         Mel(self.mel())
     }
 
     /// Convert to the unit value of a Perc struct.
     #[inline]
-    pub fn perc(&self) -> calc::Perc {
-        let Hz(hz) = *self;
+    pub fn perc(self) -> calc::Perc {
+        let Hz(hz) = self;
         perc_from_hz(hz)
     }
 
     /// Convert to a percentage of the human hearing range.
     #[inline]
-    pub fn to_perc(&self) -> Perc {
+    pub fn to_perc(self) -> Perc {
         Perc(self.perc())
     }
 
     /// Convert to a scaled percentage of the human hearing range with a given weight.
     #[inline]
-    pub fn scaled_perc_with_weight(&self, weight: ScaleWeight) -> calc::Perc {
-        let Hz(hz) = *self;
+    pub fn scaled_perc_with_weight(self, weight: ScaleWeight) -> calc::Perc {
+        let Hz(hz) = self;
         scaled_perc_from_hz(hz, weight)
     }
 
     /// Convert to a scaled percentage of the human hearing range.
     #[inline]
-    pub fn scaled_perc(&self) -> calc::Perc {
+    pub fn scaled_perc(self) -> calc::Perc {
         self.scaled_perc_with_weight(DEFAULT_SCALE_WEIGHT)
     }
 
     /// Convert to a scaled percentage of the human hearing range with a given weight.
     #[inline]
-    pub fn to_scaled_perc_with_weight(&self, weight: ScaleWeight) -> ScaledPerc {
+    pub fn to_scaled_perc_with_weight(self, weight: ScaleWeight) -> ScaledPerc {
         ScaledPerc(self.scaled_perc_with_weight(weight), weight)
     }
 
     /// Convert to a scaled percentage of the human hearing range.
     #[inline]
-    pub fn to_scaled_perc(&self) -> ScaledPerc {
+    pub fn to_scaled_perc(self) -> ScaledPerc {
         self.to_scaled_perc_with_weight(DEFAULT_SCALE_WEIGHT)
     }
 
     /// Convert to the unit value of a Step.
     #[inline]
-    pub fn step(&self) -> calc::Step {
-        let Hz(hz) = *self;
+    pub fn step(self) -> calc::Step {
+        let Hz(hz) = self;
         step_from_hz(hz)
     }
 
     /// Convert to a floating point MIDI-esque Step.
     #[inline]
-    pub fn to_step(&self) -> Step {
+    pub fn to_step(self) -> Step {
         Step(self.step())
     }
-
 }
 
 impl Add for Hz {

--- a/src/letter.rs
+++ b/src/letter.rs
@@ -9,7 +9,7 @@ use utils::modulo;
 pub const TOTAL_LETTERS: u8 = 12;
 
 /// The letter representation for each step in the 12-tone, equal temperament, chromatic scale.
-#[derive(Copy, Clone, Debug, Hash)]
+#[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde_serialization", derive(Serialize, Deserialize))]
 pub enum Letter {
     C, Csh, Db, D, Dsh, Eb, E, F, Fsh, Gb, G, Gsh, Ab, A, Ash, Bb, B
@@ -42,9 +42,9 @@ impl Eq for Letter {}
 impl Letter {
 
     /// Returns whether or not the note would be a black key on a standard piano or keyboard.
-    pub fn is_black_key(&self) -> bool {
+    pub fn is_black_key(self) -> bool {
         use self::Letter::*;
-        match *self {
+        match self {
             Csh | Db | Dsh | Eb | Fsh | Gb | Gsh | Ab | Ash | Bb => true,
             C | D | E | F | G | A | B => false,
         }

--- a/src/letter_octave.rs
+++ b/src/letter_octave.rs
@@ -20,7 +20,7 @@ use super::{
 pub type Octave = i32;
 
 /// Pitch representation in the form of a frequency (hz).
-#[derive(Debug, Copy, Clone, Hash)]
+#[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde_serialization", derive(Serialize, Deserialize))]
 pub struct LetterOctave(pub Letter, pub Octave);
 
@@ -28,99 +28,99 @@ impl LetterOctave {
 
     /// Return the value as (Letter, Octave).
     #[inline]
-    pub fn letter_octave(&self) -> (Letter, Octave) {
-        let LetterOctave(letter, octave) = *self;
+    pub fn letter_octave(self) -> (Letter, Octave) {
+        let LetterOctave(letter, octave) = self;
         (letter, octave)
     }
 
     /// Return just the Letter.
     #[inline]
-    pub fn letter(&self) -> Letter {
-        let LetterOctave(letter, _) = *self;
+    pub fn letter(self) -> Letter {
+        let LetterOctave(letter, _) = self;
         letter
     }
 
     /// Return just the octave.
     #[inline]
-    pub fn octave(&self) -> Octave {
-        let LetterOctave(_, octave) = *self;
+    pub fn octave(self) -> Octave {
+        let LetterOctave(_, octave) = self;
         octave
     }
 
     /// Convert to the unit value of Hz with the equivalent pitch.
     #[inline]
-    pub fn hz(&self) -> calc::Hz {
-        let LetterOctave(letter, octave) = *self;
+    pub fn hz(self) -> calc::Hz {
+        let LetterOctave(letter, octave) = self;
         hz_from_letter_octave(letter, octave)
     }
 
     /// Convert to a Hz with the equivalent pitch.
     #[inline]
-    pub fn to_hz(&self) -> Hz {
+    pub fn to_hz(self) -> Hz {
         Hz(self.hz())
     }
 
     /// Convert to the unit value of a Mel with equivalent pitch.
     #[inline]
-    pub fn mel(&self) -> calc::Mel {
-        let LetterOctave(letter, octave) = *self;
+    pub fn mel(self) -> calc::Mel {
+        let LetterOctave(letter, octave) = self;
         mel_from_letter_octave(letter, octave)
     }
 
     /// Convert to a Mel struct.
     #[inline]
-    pub fn to_mel(&self) -> Mel {
+    pub fn to_mel(self) -> Mel {
         Mel(self.mel())
     }
 
     /// Convert to the unit value of a Perc.
     #[inline]
-    pub fn perc(&self) -> calc::Perc {
-        let LetterOctave(letter, octave) = *self;
+    pub fn perc(self) -> calc::Perc {
+        let LetterOctave(letter, octave) = self;
         perc_from_letter_octave(letter, octave)
     }
 
     /// Convert to a percentage of the human hearing range.
     #[inline]
-    pub fn to_perc(&self) -> Perc {
+    pub fn to_perc(self) -> Perc {
         Perc(self.perc())
     }
 
     /// Convert to a scaled percentage of the human hearing range with a given weight.
     #[inline]
-    pub fn scaled_perc_with_weight(&self, weight: ScaleWeight) -> calc::Perc {
-        let LetterOctave(letter, octave) = *self;
+    pub fn scaled_perc_with_weight(self, weight: ScaleWeight) -> calc::Perc {
+        let LetterOctave(letter, octave) = self;
         scaled_perc_from_letter_octave(letter, octave, weight)
     }
 
     /// Convert to a scaled percentage of the human hearing range.
     #[inline]
-    pub fn scaled_perc(&self) -> calc::Perc {
+    pub fn scaled_perc(self) -> calc::Perc {
         self.scaled_perc_with_weight(DEFAULT_SCALE_WEIGHT)
     }
 
     /// Convert to a scaled percentage of the human hearing range with a given weight.
     #[inline]
-    pub fn to_scaled_perc_with_weight(&self, weight: ScaleWeight) -> ScaledPerc {
+    pub fn to_scaled_perc_with_weight(self, weight: ScaleWeight) -> ScaledPerc {
         ScaledPerc(self.scaled_perc_with_weight(weight), weight)
     }
 
     /// Convert to a scaled percentage of the human hearing range.
     #[inline]
-    pub fn to_scaled_perc(&self) -> ScaledPerc {
+    pub fn to_scaled_perc(self) -> ScaledPerc {
         self.to_scaled_perc_with_weight(DEFAULT_SCALE_WEIGHT)
     }
 
     /// Convert to the unit value of a Step.
     #[inline]
-    pub fn step(&self) -> calc::Step {
-        let LetterOctave(letter, octave) = *self;
+    pub fn step(self) -> calc::Step {
+        let LetterOctave(letter, octave) = self;
         step_from_letter_octave(letter, octave)
     }
 
     /// Convert to a floating point MIDI-esque Step.
     #[inline]
-    pub fn to_step(&self) -> Step {
+    pub fn to_step(self) -> Step {
         Step(self.step())
     }
 

--- a/src/mel.rs
+++ b/src/mel.rs
@@ -25,101 +25,99 @@ use super::{
 pub struct Mel(pub calc::Mel);
 
 impl Mel {
-
     /// Return the unit value of the Mel struct.
     #[inline]
-    pub fn mel(&self) -> calc::Mel {
-        let Mel(mel) = *self;
+    pub fn mel(self) -> calc::Mel {
+        let Mel(mel) = self;
         mel
     }
 
     /// Convert to hz.
     #[inline]
-    pub fn hz(&self) -> calc::Hz {
+    pub fn hz(self) -> calc::Hz {
         hz_from_mel(self.mel())
     }
 
     /// Convert to a Hz struct.
     #[inline]
-    pub fn to_hz(&self) -> Hz {
+    pub fn to_hz(self) -> Hz {
         Hz(self.hz())
     }
 
     /// Convert to (Letter, Octave) tuple.
     #[inline]
-    pub fn letter_octave(&self) -> (Letter, Octave) {
+    pub fn letter_octave(self) -> (Letter, Octave) {
         letter_octave_from_mel(self.mel())
     }
 
     /// Convert to Letter.
     #[inline]
-    pub fn letter(&self) -> Letter {
+    pub fn letter(self) -> Letter {
         let (letter, _) = self.letter_octave();
         letter
     }
 
     /// Convert to Octave.
     #[inline]
-    pub fn octave(&self) -> Octave {
+    pub fn octave(self) -> Octave {
         let (_, octave) = self.letter_octave();
         octave
     }
 
     /// Convert to LetterOctave struct with the closest pitch.
     #[inline]
-    pub fn to_letter_octave(&self) -> LetterOctave {
+    pub fn to_letter_octave(self) -> LetterOctave {
         let (letter, octave) = self.letter_octave();
         LetterOctave(letter, octave)
     }
 
     /// Convert to a percentage of the human hearing range.
     #[inline]
-    pub fn perc(&self) -> calc::Perc {
+    pub fn perc(self) -> calc::Perc {
         perc_from_mel(self.mel())
     }
 
     /// Convert to a Perc struct.
     #[inline]
-    pub fn to_perc(&self) -> Perc {
+    pub fn to_perc(self) -> Perc {
         Perc(self.perc())
     }
 
     /// Convert to a scaled percentage of the human hearing range with a given weight.
     #[inline]
-    pub fn scaled_perc_with_weight(&self, weight: ScaleWeight) -> calc::Perc {
+    pub fn scaled_perc_with_weight(self, weight: ScaleWeight) -> calc::Perc {
         scaled_perc_from_mel(self.mel(), weight)
     }
 
     /// Convert to a scaled percentage of the human hearing range.
     #[inline]
-    pub fn scaled_perc(&self) -> calc::Perc {
+    pub fn scaled_perc(self) -> calc::Perc {
         self.scaled_perc_with_weight(DEFAULT_SCALE_WEIGHT)
     }
 
     /// Convert to a scaled percentage of the human hearing range with a given weight.
     #[inline]
-    pub fn to_scaled_perc_with_weight(&self, weight: ScaleWeight) -> ScaledPerc {
+    pub fn to_scaled_perc_with_weight(self, weight: ScaleWeight) -> ScaledPerc {
         ScaledPerc(self.scaled_perc_with_weight(weight), weight)
     }
 
     /// Convert to a scaled percentage of the human hearing range.
     #[inline]
-    pub fn to_scaled_perc(&self) -> ScaledPerc {
+    pub fn to_scaled_perc(self) -> ScaledPerc {
         self.to_scaled_perc_with_weight(DEFAULT_SCALE_WEIGHT)
     }
 
     /// Convert to the unit value of a Step.
     #[inline]
-    pub fn step(&self) -> calc::Step {
+    pub fn step(self) -> calc::Step {
         step_from_mel(self.mel())
     }
 
     /// Convert to a Step struct.
     #[inline]
-    pub fn to_step(&self) -> Step {
+    pub fn to_step(self) -> Step {
         Step(self.step())
     }
-
 }
 
 impl Add for Mel {

--- a/src/perc.rs
+++ b/src/perc.rs
@@ -24,99 +24,100 @@ use super::{
 pub struct Perc(pub calc::Perc);
 
 impl Perc {
-
     /// Return the value as a percentage.
     #[inline]
-    pub fn perc(&self) -> calc::Perc { let Perc(perc) = *self; perc }
+    pub fn perc(self) -> calc::Perc {
+        let Perc(perc) = self;
+        perc
+    }
 
     /// Convert to unit value of the equivalent frequency in Hz.
     #[inline]
-    pub fn hz(&self) -> calc::Hz {
-        let Perc(perc) = *self;
+    pub fn hz(self) -> calc::Hz {
+        let Perc(perc) = self;
         hz_from_perc(perc)
     }
 
     /// Convert to the equivalent frequency in Hz.
     #[inline]
-    pub fn to_hz(&self) -> Hz {
+    pub fn to_hz(self) -> Hz {
         Hz(self.hz())
     }
 
     /// Convert to a (Letter, Octave).
     #[inline]
-    pub fn letter_octave(&self) -> (Letter, Octave) {
+    pub fn letter_octave(self) -> (Letter, Octave) {
         letter_octave_from_perc(self.perc())
     }
 
     /// Convert to Letter.
     #[inline]
-    pub fn letter(&self) -> Letter {
+    pub fn letter(self) -> Letter {
         let (letter, _) = self.letter_octave();
         letter
     }
 
     /// Convert to Octave.
     #[inline]
-    pub fn octave(&self) -> Octave {
+    pub fn octave(self) -> Octave {
         let (_, octave) = self.letter_octave();
         octave
     }
 
     /// Convert to LetterOctave.
     #[inline]
-    pub fn to_letter_octave(&self) -> LetterOctave {
+    pub fn to_letter_octave(self) -> LetterOctave {
         let (letter, octave) = self.letter_octave();
         LetterOctave(letter, octave)
     }
 
     /// Convert to the unit value of a Mel.
     #[inline]
-    pub fn mel(&self) -> calc::Mel {
+    pub fn mel(self) -> calc::Mel {
         mel_from_perc(self.perc())
     }
 
     /// Convert to a Mel struct.
     #[inline]
-    pub fn to_mel(&self) -> Mel {
+    pub fn to_mel(self) -> Mel {
         Mel(self.mel())
     }
 
     /// Convert to a scaled percentage of the human hearing range with a given weight.
     #[inline]
-    pub fn scaled_perc_with_weight(&self, weight: ScaleWeight) -> calc::Perc {
+    pub fn scaled_perc_with_weight(self, weight: ScaleWeight) -> calc::Perc {
         scaled_perc_from_perc(self.perc(), weight)
     }
 
     /// Convert to a scaled percentage of the human hearing range.
     #[inline]
-    pub fn scaled_perc(&self) -> calc::Perc {
+    pub fn scaled_perc(self) -> calc::Perc {
         self.scaled_perc_with_weight(DEFAULT_SCALE_WEIGHT)
     }
 
     /// Convert to a scaled percentage of the human hearing range with a given weight.
     #[inline]
-    pub fn to_scaled_perc_with_weight(&self, weight: ScaleWeight) -> ScaledPerc {
+    pub fn to_scaled_perc_with_weight(self, weight: ScaleWeight) -> ScaledPerc {
         ScaledPerc(self.scaled_perc_with_weight(weight), weight)
     }
 
     /// Convert to a scaled percentage of the human hearing range.
     #[inline]
-    pub fn to_scaled_perc(&self) -> ScaledPerc {
+    pub fn to_scaled_perc(self) -> ScaledPerc {
         self.to_scaled_perc_with_weight(DEFAULT_SCALE_WEIGHT)
     }
 
     /// Convert to the unit value of a Step.
     #[inline]
-    pub fn step(&self) -> calc::Step {
+    pub fn step(self) -> calc::Step {
         step_from_perc(self.perc())
     }
 
     /// Convert to a floating point MIDI-esque Step.
     #[inline]
-    pub fn to_step(&self) -> Step {
+    pub fn to_step(self) -> Step {
         Step(self.step())
     }
-
 }
 
 impl Add for Perc {

--- a/src/step.rs
+++ b/src/step.rs
@@ -24,99 +24,100 @@ use super::{
 pub struct Step(pub calc::Step);
 
 impl Step {
-
     /// Return the value in steps.
     #[inline]
-    pub fn step(&self) -> calc::Step { let Step(step) = *self; step }
+    pub fn step(self) -> calc::Step {
+        let Step(step) = self;
+        step
+    }
 
     /// Return the unit value of the equivalent frequency Hz.
     #[inline]
-    pub fn hz(&self) -> calc::Hz {
-        let Step(step) = *self;
+    pub fn hz(self) -> calc::Hz {
+        let Step(step) = self;
         hz_from_step(step)
     }
 
     /// Convert to the equivalent frequency in Hz.
     #[inline]
-    pub fn to_hz(&self) -> Hz {
+    pub fn to_hz(self) -> Hz {
         Hz(self.hz())
     }
 
     /// Convert to the closest equivalent (Letter, Octave).
     #[inline]
-    pub fn letter_octave(&self) -> (Letter, Octave) {
+    pub fn letter_octave(self) -> (Letter, Octave) {
         letter_octave_from_step(self.step())
     }
 
     /// Convert to the closest equivalent Letter.
     #[inline]
-    pub fn letter(&self) -> Letter {
+    pub fn letter(self) -> Letter {
         let (letter, _) = self.letter_octave();
         letter
     }
 
     /// Convert to the closest equivalent Octave.
     #[inline]
-    pub fn octave(&self) -> Octave {
+    pub fn octave(self) -> Octave {
         let (_, octave) = self.letter_octave();
         octave
     }
 
     /// Convert to the closest equivalent LetterOctave.
     #[inline]
-    pub fn to_letter_octave(&self) -> LetterOctave {
+    pub fn to_letter_octave(self) -> LetterOctave {
         let (letter, octave) = self.letter_octave();
         LetterOctave(letter, octave)
     }
 
     /// Convert to a Mel unit value.
     #[inline]
-    pub fn mel(&self) -> calc::Mel {
+    pub fn mel(self) -> calc::Mel {
         mel_from_step(self.step())
     }
 
     /// Convert to a Mel struct.
     #[inline]
-    pub fn to_mel(&self) -> Mel {
+    pub fn to_mel(self) -> Mel {
         Mel(self.mel())
     }
 
     /// Convert to the unit value of the equivalent Perc.
     #[inline]
-    pub fn perc(&self) -> calc::Perc {
+    pub fn perc(self) -> calc::Perc {
         perc_from_step(self.step())
     }
 
     /// Convert to a percentage of the human hearing range.
     #[inline]
-    pub fn to_perc(&self) -> Perc {
+    pub fn to_perc(self) -> Perc {
         Perc(self.perc())
     }
 
     /// Convert to a scaled percentage of the human hearing range with a given weight.
     #[inline]
-    pub fn scaled_perc_with_weight(&self, weight: ScaleWeight) -> calc::Perc {
+    pub fn scaled_perc_with_weight(self, weight: ScaleWeight) -> calc::Perc {
         scaled_perc_from_step(self.step(), weight)
     }
 
     /// Convert to a scaled percentage of the human hearing range.
     #[inline]
-    pub fn scaled_perc(&self) -> calc::Perc {
+    pub fn scaled_perc(self) -> calc::Perc {
         self.scaled_perc_with_weight(DEFAULT_SCALE_WEIGHT)
     }
 
     /// Convert to a scaled percentage of the human hearing range with a given weight.
     #[inline]
-    pub fn to_scaled_perc_with_weight(&self, weight: ScaleWeight) -> ScaledPerc {
+    pub fn to_scaled_perc_with_weight(self, weight: ScaleWeight) -> ScaledPerc {
         ScaledPerc(self.scaled_perc_with_weight(weight), weight)
     }
 
     /// Convert to a scaled percentage of the human hearing range.
     #[inline]
-    pub fn to_scaled_perc(&self) -> ScaledPerc {
+    pub fn to_scaled_perc(self) -> ScaledPerc {
         self.to_scaled_perc_with_weight(DEFAULT_SCALE_WEIGHT)
     }
-
 }
 
 impl Add for Step {


### PR DESCRIPTION
While working on #26 I ran clippy and saw two errors and a lot of warning so I decided to apply the lints and fix the error caused by deriving `Hash` while implicitly having `PartialEq` already derived.

The following lints were applied:

- https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref
- https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#cast_lossless
- https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#derive_hash_xor_eq

How to install clippy and run:

$ rustup component add --toolchain nightly clippy-preview
$ cargo +nightly clippy