### PR TITLE
Update serde syntax to use features = [derive]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,8 @@ homepage = "https://github.com/RustAudio/pitch_calc"
 [dependencies]
 num = "0.1.28"
 rand = "0.3.12"
-serde = { optional = true, version = "1.0.8" }
-serde_derive = { optional = true, version = "1.0.8" }
+serde = { optional = true, version = "1.0.*", features = ["derive"] }
 serde_json = { optional = true, version = "1.0.2" }
 
 [features]
-serde_serialization = ["serde", "serde_derive", "serde_json"]
+serde_serialization = ["serde", "serde_json"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,8 @@ extern crate num;
 extern crate rand;
 
 #[cfg(feature="serde_serialization")]
+#[macro_use]
 extern crate serde;
-#[cfg(feature="serde_serialization")]
-#[macro_use] extern crate serde_derive;
 
 pub use self::calc::{
     difference_in_semitones,


### PR DESCRIPTION
Almost everything was already prepared for serialisation here, I just needed to update to the current serde crate syntax with `features = ["derive"]` to get it to work. 
Possibly one could remove the serde_json dependency and rename the feature "serde" for consistency with time_calc, but it could also be an unnecessary breaking change.