### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ homepage = "https://github.com/RustAudio/pitch_calc"
 edition = "2018"
 
 [dependencies]
-num = "0.1.28"
-rand = "0.3.12"
+num = ">=0.1.28, <1"
+rand = ">=0.3.12, <1"
 serde = { optional = true, version = "1.0.*", features = ["derive"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 num = ">=0.1.28, <1"
-rand = ">=0.3.12, <1"
+rand = ">=0.5, <1"
 serde = { optional = true, version = "1.0.*", features = ["derive"] }
 
 [dev-dependencies]

--- a/src/letter.rs
+++ b/src/letter.rs
@@ -136,8 +136,8 @@ impl ToPrimitive for Letter {
     }
 }
 
-impl ::rand::Rand for Letter {
-    fn rand<R: ::rand::Rng>(rng: &mut R) -> Letter {
+impl ::rand::distributions::Distribution<Letter> for ::rand::distributions::Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Letter {
         rng.gen_range(0, 12).to_letter()
     }
 }


### PR DESCRIPTION
The dependencies are quite old, and I couldn't compile the crate in my project which uses a more recent version of `rand`.

I've made the `num` dependency a greater range of versions, as long as they are below v1.

I've raised the minimum version of `rand` to 0.5, which is when the `Rand` trait was deprecated, and changed the implementation of `Rand` for `Letter` to conform to the newer API.